### PR TITLE
filter: aws ec2 tags (unit tests) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,8 @@ add_subdirectory(${FLB_PATH_LIB_JSMN})
 # Runtime Tests (filter_kubernetes) requires HTTP Server
 if(FLB_TESTS_RUNTIME)
   FLB_OPTION(FLB_HTTP_SERVER  ON)
+  add_definitions(-DFLB_FILTER_AWS_IMDS_HOST="127.0.0.1")
+  add_definitions(-DFLB_FILTER_AWS_IMDS_PORT=8000)
 endif()
 
 # MK Core

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -167,7 +167,7 @@ static int cb_aws_init(struct flb_filter_instance *f_ins,
 
     ctx->ec2_upstream = flb_upstream_create(config,
                                             FLB_FILTER_AWS_IMDS_HOST,
-                                            80,
+                                            FLB_FILTER_AWS_IMDS_PORT,
                                             FLB_IO_TCP,
                                             NULL);
     if (!ctx->ec2_upstream) {
@@ -215,7 +215,7 @@ static int get_ec2_token(struct flb_filter_aws *ctx)
     client = flb_http_client(u_conn, FLB_HTTP_PUT,
                              FLB_FILTER_AWS_IMDS_V2_TOKEN_PATH,
                              NULL, 0, FLB_FILTER_AWS_IMDS_HOST,
-                             80, NULL, 0);
+                             FLB_FILTER_AWS_IMDS_PORT, NULL, 0);
 
     if (!client) {
         flb_plg_error(ctx->ins, "count not create http client");
@@ -283,7 +283,7 @@ static int get_metadata_by_key(struct flb_filter_aws *ctx, char *metadata_path,
     client = flb_http_client(u_conn,
                              FLB_HTTP_GET, metadata_path,
                              NULL, 0,
-                             FLB_FILTER_AWS_IMDS_HOST, 80,
+                             FLB_FILTER_AWS_IMDS_HOST, FLB_FILTER_AWS_IMDS_PORT,
                              NULL, 0);
 
     if (!client) {

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -31,7 +31,12 @@
 
 #define FLB_FILTER_AWS_IMDS_V2_TOKEN_TTL                  21600
 
+#ifndef FLB_FILTER_AWS_IMDS_HOST
 #define FLB_FILTER_AWS_IMDS_HOST                          "169.254.169.254"
+#endif
+#ifndef FLB_FILTER_AWS_IMDS_PORT
+#define FLB_FILTER_AWS_IMDS_PORT                          80
+#endif
 #define FLB_FILTER_AWS_IMDS_V2_TOKEN_PATH                 "/latest/api/token"
 
 #define FLB_FILTER_AWS_IMDS_INSTANCE_ID_PATH              "/latest/meta-data/instance-id/"

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 
 # Filter Plugins
 if(FLB_IN_LIB AND FLB_OUT_LIB)
+  FLB_RT_TEST(FLB_FILTER_AWS             "filter_aws.c")
   FLB_RT_TEST(FLB_FILTER_CHECKLIST       "filter_checklist.c")
   FLB_RT_TEST(FLB_FILTER_EXPECT          "filter_expect.c")
   FLB_RT_TEST(FLB_FILTER_STDOUT          "filter_stdout.c")

--- a/tests/runtime/filter_aws.c
+++ b/tests/runtime/filter_aws.c
@@ -1,0 +1,214 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <stdlib.h>
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include "flb_tests_runtime.h"
+
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+char *output = NULL;
+
+void set_output(char *val)
+{
+    pthread_mutex_lock(&result_mutex);
+    output = val;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+char *get_output(void)
+{
+    char *val;
+
+    pthread_mutex_lock(&result_mutex);
+    val = output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return val;
+}
+
+int callback_test(void* data, size_t size, void* cb_data)
+{
+    if (size > 0) {
+        flb_debug("[test_filter_aws] received message: %s", data);
+        set_output(data); /* success */
+    }
+    return 0;
+}
+
+
+int run_aws_ec2_metadata_server(bool no_tags) {
+    int pid = fork();
+    if (pid == 0) {
+        flb_info("running in child process");
+        if (!no_tags) {
+            char *args[] = {"bash", "-c", "python3 ../tests/runtime/filter_aws_ec2ws_server.py", NULL};
+            execvp(args[0], args);
+        } else {
+            char *args[] = {"bash", "-c", "python3 ../tests/runtime/filter_aws_ec2ws_server.py no_tags", NULL};
+            execvp(args[0], args);
+        }
+        return 0;
+    }
+    sleep(1);
+    return pid;
+}
+
+void flb_test_aws_ec2_tags_present() {
+    int server_pid = run_aws_ec2_metadata_server(false);
+
+    int i;
+    int ret;
+    int bytes;
+    char *p = "[0, {\"log\": \"hello, from my ec2 instance\"}]";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "format", "json",
+                   NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "aws", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "ec2_instance_id", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "az", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "tags_enabled", "true", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    if (!TEST_CHECK(bytes > 0)) {
+        TEST_MSG("zero bytes were pushed\n");
+    }
+
+    flb_time_msleep(1500);
+
+    char *output = NULL;
+    output = get_output();
+
+    char *result = strstr(output, "\"Name\":\"mwarzynski-fluentbit-dev\"");
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "\"CUSTOMER_ID\":\"70ec5c04-3a6e-11ed-a261-0242ac120002\"");
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "hello, from my ec2 instance");
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    set_output(NULL);
+    kill(server_pid, SIGINT);
+}
+
+
+void flb_test_aws_ec2_tags_404() {
+    int server_pid = run_aws_ec2_metadata_server(true);
+
+    int i;
+    int ret;
+    int bytes;
+    char *p = "[0, {\"log\": \"hello, from my ec2 instance\"}]";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "format", "json",
+                   NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "aws", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "ec2_instance_id", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "az", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "tags_enabled", "true", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    if (!TEST_CHECK(bytes > 0)) {
+        TEST_MSG("zero bytes were pushed\n");
+    }
+
+    flb_time_msleep(1500);
+
+    char *output = NULL;
+    output = get_output();
+
+    char *result = strstr(output, "\"Name\":\"mwarzynski-fluentbit-dev\"");
+    if (!TEST_CHECK(result == NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "\"CUSTOMER_ID\":\"70ec5c04-3a6e-11ed-a261-0242ac120002\"");
+    if (!TEST_CHECK(result == NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "hello, from my ec2 instance");
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    set_output(NULL);
+    kill(server_pid, SIGINT);
+}
+
+TEST_LIST = {
+    {"aws_ec2_tags_present", flb_test_aws_ec2_tags_present},
+    {"aws_ec2_tags_404", flb_test_aws_ec2_tags_404},
+    {NULL, NULL}
+};

--- a/tests/runtime/filter_aws_ec2ws_server.py
+++ b/tests/runtime/filter_aws_ec2ws_server.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+SHOULD_RETURN_TAGS = True
+
+
+class HTTPHandler(BaseHTTPRequestHandler):
+    def _send_response(self, status_code: int = 200, body: str = None):
+        self.send_response(status_code)
+        if body:
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", len(body))
+        self.end_headers()
+        if body:
+            self.wfile.write(body.encode("utf-8"))
+
+    def do_GET(self):
+        if self.path == "/latest/meta-data/instance-id/":
+            self._send_response(body="i-0e66fc7f9809d7168")
+
+        elif self.path == "/latest/meta-data/placement/availability-zone/":
+            self._send_response(body="us-east-1a")
+
+        elif self.path == "/latest/meta-data/tags/instance":
+            if not SHOULD_RETURN_TAGS:
+                # If there are 0 tags, AWS returns a 404.
+                self._send_response(status_code=404)
+            else:
+                self._send_response(body="Name\nCUSTOMER_ID")
+
+        elif self.path == "/latest/meta-data/tags/instance/Name":
+            self._send_response(body="mwarzynski-fluentbit-dev")
+
+        elif self.path == "/latest/meta-data/tags/instance/CUSTOMER_ID":
+            self._send_response(body="70ec5c04-3a6e-11ed-a261-0242ac120002")
+
+        else:
+            self._send_response(status_code=500)
+
+    def do_PUT(self):
+        self._send_response(status_code=200)
+
+
+def run():
+    if len(sys.argv) == 2 and "no_tags" == sys.argv[1]:
+        global SHOULD_RETURN_TAGS
+        SHOULD_RETURN_TAGS = False
+    httpd = HTTPServer(("", 8000), HTTPHandler)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
<!-- Provide summary of changes -->

```
$ ctest  --verbose --output-on-failure -R 'filter_aws' .

UpdateCTestConfiguration  from :/fluent-bit-dev/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/fluent-bit-dev/build/DartConfiguration.tcl
Test project /fluent-bit-dev/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 20
    Start 20: flb-rt-filter_aws

20: Test command: /fluent-bit-dev/build/bin/flb-rt-filter_aws
20: Test timeout computed to be: 10000000
20: Test aws_ec2_tags_present...                    [2022/09/22 19:28:35] [ info] running in child process
20: [2022/09/22 19:28:36] [ info] [fluent bit] version=2.0.0, commit=29d7ee714e, pid=106171
20: [2022/09/22 19:28:36] [ info] [storage] version=1.3.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
20: [2022/09/22 19:28:36] [ info] [cmetrics] version=0.4.0
20: 127.0.0.1 - - [22/Sep/2022 19:28:36] "PUT /latest/api/token HTTP/1.1" 200 -
20: 127.0.0.1 - - [22/Sep/2022 19:28:36] "GET /latest/meta-data/tags/instance HTTP/1.1" 200 -
20: 127.0.0.1 - - [22/Sep/2022 19:28:36] "GET /latest/meta-data/tags/instance/Name HTTP/1.1" 200 -
20: 127.0.0.1 - - [22/Sep/2022 19:28:36] "GET /latest/meta-data/tags/instance/CUSTOMER_ID HTTP/1.1" 200 -
20: [2022/09/22 19:28:36] [ info] [sp] stream processor started
20: [2022/09/22 19:28:38] [ warn] [engine] service will shutdown in max 5 seconds
20: [2022/09/22 19:28:38] [ info] [engine] service has stopped (0 pending tasks)
20: [ OK ]
20: Test aws_ec2_tags_404...                        [2022/09/22 19:28:38] [ info] running in child process
20: [2022/09/22 19:28:39] [ info] [fluent bit] version=2.0.0, commit=29d7ee714e, pid=106175
20: [2022/09/22 19:28:39] [ info] [storage] version=1.3.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
20: [2022/09/22 19:28:39] [ info] [cmetrics] version=0.4.0
20: 127.0.0.1 - - [22/Sep/2022 19:28:39] "PUT /latest/api/token HTTP/1.1" 200 -
20: 127.0.0.1 - - [22/Sep/2022 19:28:39] "GET /latest/meta-data/tags/instance HTTP/1.1" 404 -
20: [2022/09/22 19:28:39] [ warn] [filter:aws:aws.0] tags not available in the EC2 instance metadata
20: [2022/09/22 19:28:39] [ info] [sp] stream processor started
20: [2022/09/22 19:28:40] [ warn] [engine] service will shutdown in max 5 seconds
20: [2022/09/22 19:28:41] [ info] [engine] service has stopped (0 pending tasks)
20: [ OK ]
20: SUCCESS: All unit tests have passed.
1/1 Test #20: flb-rt-filter_aws ................   Passed    5.79 sec

The following tests passed:
	flb-rt-filter_aws

100% tests passed, 0 tests failed out of 1

Label Time Summary:
runtime    =   5.79 sec*proc (1 test)

Total Test time (real) =   5.80 sec
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
